### PR TITLE
allow the setting of new template tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ grunt.initConfig({
         output_directory: 'test/output/extra_data/',
         data: {
           "foo": "bar"
+        },
+        templatetoken: {
+          evaluate:      /\{\{(.+?)\}\}/g,
+          interpolate:   /\{\{=(.+?)\}\}/g,
+          escape:        /\{\{-(.+?)\}\}/g
         }
       },
       files: {
@@ -242,6 +247,23 @@ Will generate
 Check out this <a href="http://example.com">example</a> 
 ```
 
+### Changing default template tokens.
+
+There may be occasions when you are using the generator and you need to output client side templates to be rendered. If these client side templates use the same token i.e ```<% %>``` then the genrator will of course attempt to render these!
+
+One option is to change token on your client side templating solution, but this may not always be possible as there maybe a dependency outside your scope.
+
+```templatetoken``` exposes [lodash's option to change template tokens](http://documentcloud.github.io/underscore/#template).
+
+For example, to perform Mustache.js style templating:
+
+```
+templatetoken: {
+    evaluate:      /\{\{(.+?)\}\}/g,
+    interpolate:   /\{\{=(.+?)\}\}/g,
+    escape:        /\{\{-(.+?)\}\}/g
+  }
+```
 
 
 ## Thanks

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-multi-lang-site-generator",
   "description": "Runs templates and i18n at grunt's compile time.",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "homepage": "http://github.com/BBCVisualJournalism/grunt-multi-lang-site-generator.git",
   "contributors": [{
     "name": "Tom Maslen",

--- a/tasks/multi_lang_site_generator.js
+++ b/tasks/multi_lang_site_generator.js
@@ -97,7 +97,6 @@ module.exports = function (grunt) {
     }
 
     function we_dont_have (object) {
-        console.log(object);
         if(typeof object === 'undefined') {
             return true;
         }

--- a/tasks/multi_lang_site_generator.js
+++ b/tasks/multi_lang_site_generator.js
@@ -97,6 +97,10 @@ module.exports = function (grunt) {
     }
 
     function we_dont_have (object) {
+        console.log(object);
+        if(typeof object === 'undefined') {
+            return true;
+        }
         return object.length < 1;
     }
 

--- a/tasks/multi_lang_site_generator.js
+++ b/tasks/multi_lang_site_generator.js
@@ -18,10 +18,6 @@ module.exports = function (grunt) {
             languages = get_list_of_languages(options.vocabs, options.vocab_directory),
             files     = this.files;
 
-        if (!!options.templatetoken) {
-            updateLodashTemplateTokenSettings(options.templatetoken);
-        }
-
         validate_options(grunt, options, files);
 
         languages.forEach(function (lng) {
@@ -58,6 +54,12 @@ module.exports = function (grunt) {
 
     function validate_options (grunt, options, files) {
         grunt.verbose.writeflags(options, 'Options');
+        
+        if (we_dont_have(options.templatetoken)) {
+            grunt.log.writeln('Using default template token');
+        } else {
+            updateLodashTemplateTokenSettings(options.templatetoken);
+        }
         
         if (we_dont_have(options.vocabs)) {
             grunt.log.warn('Cannot run without any vocabs defined.');

--- a/tasks/multi_lang_site_generator.js
+++ b/tasks/multi_lang_site_generator.js
@@ -18,6 +18,10 @@ module.exports = function (grunt) {
             languages = get_list_of_languages(options.vocabs, options.vocab_directory),
             files     = this.files;
 
+        if (!!options.templatetoken) {
+            updateLodashTemplateTokenSettings(options.templatetoken);
+        }
+
         validate_options(grunt, options, files);
 
         languages.forEach(function (lng) {
@@ -26,6 +30,18 @@ module.exports = function (grunt) {
             });
         });
     });
+
+    function updateLodashTemplateTokenSettings (token) {
+        if(typeof token.evaluate !== 'undefined') {
+            _.templateSettings.evaluate = token.evaluate;
+        }
+        if(typeof token.interpolate !== 'undefined') {
+            _.templateSettings.interpolate = token.interpolate;
+        }
+        if(typeof token.escape !== 'undefined') {
+            _.templateSettings.escape = token.escape;
+        }
+    }
 
     function get_list_of_languages (vocabs, vocab_directory) {
         var list_of_languages = [];


### PR DESCRIPTION
![](http://img.pandawhale.com/56179-cat-on-keyboard-typing-gif-hI43.gif)

This PR allows for the user to pass through templateSetting to lodash from the Grunt task so we can change the template tokens

Usage

```
options: {
  templatetoken: {
    evaluate:      /\{\{(.+?)\}\}/g,
    interpolate:   /\{\{=(.+?)\}\}/g,
    escape:        /\{\{-(.+?)\}\}/g
  }
}
```